### PR TITLE
Fix duplicated zerocopy import and bump version.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ exclude = ["/fixture"]
 [dependencies]
 bitflags = "2"
 thiserror = "1"
-zerocopy = "0.7.32"
-zerocopy-derive = "0.7.32"
+zerocopy = "0.7.35"
+zerocopy-derive = "0.7.35"
 arrayvec = "0.7"
 
 [dev-dependencies]

--- a/src/x86_64.rs
+++ b/src/x86_64.rs
@@ -6,13 +6,12 @@
 use arrayvec::ArrayVec;
 use std::ops::ControlFlow;
 use thiserror::Error;
-use zerocopy::{FromBytes, Ref, Unaligned, LE};
 use zerocopy_derive::{FromBytes, FromZeroes, Unaligned};
 
-type U16 = zerocopy::U16<LE>;
+type U16 = zerocopy::U16<zerocopy::LE>;
 
 /// Little-endian u32.
-pub type U32 = zerocopy::U32<LE>;
+pub type U32 = zerocopy::U32<zerocopy::LE>;
 
 /// A view over function table entries in the `.pdata` section.
 #[derive(Debug, Clone, Copy)]
@@ -46,7 +45,7 @@ impl<'a> FunctionTableEntries<'a> {
     /// Get the `RuntimeFunction`s in the function table, if the parsed data is well-aligned and
     /// sized.
     pub fn functions(&self) -> Option<&'a [RuntimeFunction]> {
-        Ref::new_slice_unaligned(self.data).map(|lv| lv.into_slice())
+        zerocopy::Ref::new_slice_unaligned(self.data).map(|lv| lv.into_slice())
     }
 
     /// Lookup the runtime function that contains the given relative virtual address.
@@ -160,7 +159,7 @@ impl<'a> Iterator for FunctionTableEntries<'a> {
     type Item = &'a RuntimeFunction;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let (rf, rest) = Ref::<_, RuntimeFunction>::new_unaligned_from_prefix(self.data)?;
+        let (rf, rest) = zerocopy::Ref::<_, RuntimeFunction>::new_unaligned_from_prefix(self.data)?;
         self.data = rest;
         Some(rf.into_ref())
     }
@@ -174,13 +173,15 @@ struct Sections<'a> {
 
 impl<'a> Sections<'a> {
     pub fn parse(image: &'a [u8]) -> Option<Self> {
-        let sig_offset = Ref::<_, U32>::new_unaligned(image.get(0x3c..0x40)?)?.get() as usize;
+        let sig_offset =
+            zerocopy::Ref::<_, U32>::new_unaligned(image.get(0x3c..0x40)?)?.get() as usize;
         // Offset to the COFF header
         let coff_image = image.get(sig_offset + 4..)?;
-        let section_count = Ref::<_, U16>::new_unaligned(coff_image.get(2..4)?)?.get() as usize;
+        let section_count =
+            zerocopy::Ref::<_, U16>::new_unaligned(coff_image.get(2..4)?)?.get() as usize;
         let size_of_optional_header =
-            Ref::<_, U16>::new_unaligned(coff_image.get(16..18)?)?.get() as usize;
-        let sections = Ref::<_, [Section]>::new_slice_unaligned_from_prefix(
+            zerocopy::Ref::<_, U16>::new_unaligned(coff_image.get(16..18)?)?.get() as usize;
+        let sections = zerocopy::Ref::<_, [Section]>::new_slice_unaligned_from_prefix(
             &coff_image[20 + size_of_optional_header..],
             section_count,
         )?
@@ -526,7 +527,7 @@ impl FunctionEpilogInstruction {
         if allow_add_sp && ip.len() >= 3 {
             // add RSP,imm32
             if rex & 0x8 != 0 && ip[0] == 0x81 && ip[1] == 0xc4 {
-                let (val, rest) = Ref::<_, U32>::new_unaligned_from_prefix(&ip[2..])
+                let (val, rest) = zerocopy::Ref::<_, U32>::new_unaligned_from_prefix(&ip[2..])
                     .ok_or(InstructionParseError::NotEnoughData)?;
                 return Ok(Some((FunctionEpilogInstruction::AddSP(val.get()), rest)));
             }
@@ -551,8 +552,9 @@ impl FunctionEpilogInstruction {
                             )));
                         // lea RSP,disp32[FP]
                         } else if op_mod == 0b10 {
-                            let (val, rest) = Ref::<_, U32>::new_unaligned_from_prefix(&ip[2..])
-                                .ok_or(InstructionParseError::NotEnoughData)?;
+                            let (val, rest) =
+                                zerocopy::Ref::<_, U32>::new_unaligned_from_prefix(&ip[2..])
+                                    .ok_or(InstructionParseError::NotEnoughData)?;
                             return Ok(Some((
                                 FunctionEpilogInstruction::AddSPFromFP(val.get()),
                                 rest,
@@ -707,12 +709,14 @@ impl<'a> UnwindInfo<'a> {
     ///
     /// Returns None if there aren't enough bytes or the alignment is incorrect.
     pub fn parse(data: &'a [u8]) -> Option<Self> {
-        let (header, rest) = Ref::<_, UnwindInfoHeader>::new_unaligned_from_prefix(data)?;
+        let (header, rest) = zerocopy::Ref::<_, UnwindInfoHeader>::new_unaligned_from_prefix(data)?;
         if header.version() != 1 {
             return None;
         }
-        let (unwind_codes, rest) =
-            Ref::new_slice_unaligned_from_prefix(rest, header.unwind_codes_len as usize * 2)?;
+        let (unwind_codes, rest) = zerocopy::Ref::new_slice_unaligned_from_prefix(
+            rest,
+            header.unwind_codes_len as usize * 2,
+        )?;
         Some(UnwindInfo {
             header: header.into_ref(),
             unwind_codes: unwind_codes.into_slice(),
@@ -730,20 +734,21 @@ impl<'a> UnwindInfo<'a> {
         let flags = self.flags();
         if flags.contains(UnwindInfoFlags::EHANDLER) {
             let (handler_address, handler_data) =
-                Ref::<_, U32>::new_unaligned_from_prefix(self.rest)?;
+                zerocopy::Ref::<_, U32>::new_unaligned_from_prefix(self.rest)?;
             Some(UnwindInfoTrailer::ExceptionHandler {
                 handler_address: handler_address.into_ref(),
                 handler_data,
             })
         } else if flags.contains(UnwindInfoFlags::UHANDLER) {
             let (handler_address, handler_data) =
-                Ref::<_, U32>::new_unaligned_from_prefix(self.rest)?;
+                zerocopy::Ref::<_, U32>::new_unaligned_from_prefix(self.rest)?;
             Some(UnwindInfoTrailer::TerminationHandler {
                 handler_address: handler_address.into_ref(),
                 handler_data,
             })
         } else if flags.contains(UnwindInfoFlags::CHAININFO) {
-            let (chained, _) = Ref::<_, RuntimeFunction>::new_unaligned_from_prefix(self.rest)?;
+            let (chained, _) =
+                zerocopy::Ref::<_, RuntimeFunction>::new_unaligned_from_prefix(self.rest)?;
             Some(UnwindInfoTrailer::ChainedUnwindInfo {
                 chained: chained.into_ref(),
             })
@@ -775,8 +780,8 @@ impl<'a> UnwindOperations<'a> {
         c.read::<UnwindCode>()
     }
 
-    fn read<T: Unaligned + FromBytes>(&mut self) -> Option<&'a T> {
-        let (v, rest) = Ref::<_, T>::new_unaligned_from_prefix(self.0)?;
+    fn read<T: zerocopy::Unaligned + zerocopy::FromBytes>(&mut self) -> Option<&'a T> {
+        let (v, rest) = zerocopy::Ref::<_, T>::new_unaligned_from_prefix(self.0)?;
         self.0 = rest;
         Some(v.into_ref())
     }


### PR DESCRIPTION
I was getting the error:

``` shell
error[E0252]: the name `FromBytes` is defined multiple times
  --> /var/home/cameron/.var/app/com.vscodium.codium/data/cargo/registry/src/index.crates.io-6f17d22bba15001f/pe-unwind-info-0.2.3/src/x86_64.rs:10:23
   |
9  | use zerocopy::{FromBytes, Ref, Unaligned, LE};
   |                --------- previous import of the macro `FromBytes` here
10 | use zerocopy_derive::{FromBytes, FromZeroes, Unaligned};
   |                       ^^^^^^^^^--
   |                       |
   |                       `FromBytes` reimported here
   |                       help: remove unnecessary import
   |
   = note: `FromBytes` must be defined only once in the macro namespace of this module

error[E0252]: the name `Unaligned` is defined multiple times
  --> /var/home/cameron/.var/app/com.vscodium.codium/data/cargo/registry/src/index.crates.io-6f17d22bba15001f/pe-unwind-info-0.2.3/src/x86_64.rs:10:46
   |
9  | use zerocopy::{FromBytes, Ref, Unaligned, LE};
   |                                --------- previous import of the macro `Unaligned` here
10 | use zerocopy_derive::{FromBytes, FromZeroes, Unaligned};
   |                                              ^^^^^^^^^ `Unaligned` reimported here
   |
   = note: `Unaligned` must be defined only once in the macro namespace of this module
```

so I qualified the `zerocopy` imports, and bumped the version while I'm at it.